### PR TITLE
Move live-frame streaming to ESP32 hub

### DIFF
--- a/swine-esp32/live_frame_uploader.cpp
+++ b/swine-esp32/live_frame_uploader.cpp
@@ -1,0 +1,41 @@
+#include "live_frame_uploader.h"
+#include "swinetrack_http.h"
+
+namespace swt {
+
+struct UploadCfg {
+  String camUrl;
+  const char* fnBase;
+  const char* deviceId;
+  const char* deviceSecret;
+  uint32_t intervalMs;
+};
+
+static UploadCfg g_cfg;
+
+static void liveFrameTask(void* arg) {
+  std::vector<uint8_t> jpeg;
+  for (;;) {
+    jpeg.clear();
+    if (fetchCamera(g_cfg.camUrl, jpeg)) {
+      // Minimal payload: JPEG plus empty thermal/reading JSON
+      String empty = "{}";
+      postMultipart(g_cfg.fnBase, g_cfg.deviceId, g_cfg.deviceSecret,
+                    "/ingest-live-frame", jpeg, empty, "");
+    }
+    jpeg.clear();
+    vTaskDelay(pdMS_TO_TICKS(g_cfg.intervalMs));
+  }
+}
+
+void startLiveFrameUploader(const String& cameraUrl,
+                            const char* fnBase,
+                            const char* deviceId,
+                            const char* deviceSecret,
+                            uint32_t intervalMs) {
+  g_cfg = {cameraUrl, fnBase, deviceId, deviceSecret, intervalMs};
+  xTaskCreatePinnedToCore(liveFrameTask, "live_frame_uploader", 8192, nullptr, 1, nullptr, 1);
+}
+
+}  // namespace swt
+

--- a/swine-esp32/live_frame_uploader.h
+++ b/swine-esp32/live_frame_uploader.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <Arduino.h>
+#include <vector>
+
+namespace swt {
+
+// Start a background task that fetches JPEG frames from the camera URL and
+// uploads them to the backend at the requested interval (ms). This is intended
+// for high-throughput live streaming (~30 FPS).
+void startLiveFrameUploader(const String& cameraUrl,
+                            const char* fnBase,
+                            const char* deviceId,
+                            const char* deviceSecret,
+                            uint32_t intervalMs);
+
+}  // namespace swt
+

--- a/swine-esp32/swine-esp32.ino
+++ b/swine-esp32/swine-esp32.ino
@@ -1,6 +1,7 @@
 // ==== SwiNetTrack — ESP32 Hub (minimal main) ====
 #include "swinetrack_http.h"
 #include "swinetrack_sensors.h"
+#include "live_frame_uploader.h"
 
 using namespace swt;  // just for brevity below
 
@@ -26,7 +27,7 @@ Adafruit_MLX90640 mlx;
 float mlxFrame[32 * 24];
 float gasBaseline = 0;
 
-uint32_t lastLive = 0, lastReading = 0;
+uint32_t lastReading = 0;
 
 void setup() {
   Serial.begin(115200);
@@ -54,6 +55,8 @@ void setup() {
   swt::fetchConfig(FN_BASE, DEVICE_ID, DEVICE_SECRET,
                    CAMERA_URL, LIVE_FRAME_INTERVAL_MS, READING_INTERVAL_MS,
                    OVERLAY_ALPHA, FEVER_C);
+
+  startLiveFrameUploader(CAMERA_URL, FN_BASE, DEVICE_ID, DEVICE_SECRET, LIVE_FRAME_INTERVAL_MS);
 
   // (Optional) quick health check to the same domain
   // swt::postPing(FN_BASE);
@@ -93,49 +96,6 @@ void loop() {
       _tmp = String();                                            // free temp String
       lastReading = now;
     }
-  }
-
-  // --- camera fetch backoff on failures ---
-  static uint8_t camFailCount = 0;
-  static uint32_t camBackoffUntil = 0;
-  if (camBackoffUntil && now < camBackoffUntil) {
-    // Skip work while backing off
-    delay(20);
-    return;
-  }
-
-  // --- near-live frame push (overwrite) ---
-  if (now - lastLive >= LIVE_FRAME_INTERVAL_MS) {
-    std::vector<uint8_t> jpeg;
-    if (swt::fetchCamera(CAMERA_URL, jpeg)) {
-      // success: reset backoff
-      camFailCount = 0;
-      camBackoffUntil = 0;
-
-      // refresh thermal right before upload
-      readMLX90640(mlx, mlxFrame);
-      String thJson = makeThermalJson(mlxFrame, tMin, tMax, tAvg);
-      String rdJson = makeReadingJson(lastTemp, lastHum, lastPress, lastGas, /*iaq*/ lastIAQ, tMin, tMax, tAvg);
-
-      bool ok = swt::postMultipart(FN_BASE, DEVICE_ID, DEVICE_SECRET,
-                                   "/ingest-live-frame", jpeg, thJson, rdJson);
-      if (!ok) {
-        Serial.println("live-frame upload failed");
-        // treat like a failure to slow down a bit
-        camFailCount = min<uint8_t>(camFailCount + 1, 6);
-        camBackoffUntil = now + (1000UL << camFailCount);  // 1s,2s,4s,...64s
-      }
-
-      // free big buffers asap
-      std::vector<uint8_t>().swap(jpeg);
-      thJson = String();
-      rdJson = String();
-    } else {
-      Serial.println("camera fetch failed");
-      camFailCount = min<uint8_t>(camFailCount + 1, 6);
-      camBackoffUntil = now + (1000UL << camFailCount);  // exponential backoff
-    }
-    lastLive = now;
   }
 
   // --- simple alert heuristic with cooldown ---


### PR DESCRIPTION
## Summary
- restore stock ESP32-CAM sketch and HTTP server, dropping unused pipeline files
- add live-frame uploader task on ESP32 hub for high throughput
- start uploader from hub sketch and remove near-live push logic

## Testing
- `platformio ci --board esp32cam swine-esp32-cam/swine-esp32-cam.ino` *(fails: HTTPClientError)*
- `platformio ci --board esp32dev swine-esp32/swine-esp32.ino` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cb1d79f4832e909cef0ca66ec70f