### PR TITLE
Create alerts when ingesting snapshots

### DIFF
--- a/supabase/functions/ingest-snapshot/_auth.ts
+++ b/supabase/functions/ingest-snapshot/_auth.ts
@@ -55,5 +55,12 @@ export async function verify(req: Request) {
   // Optionally: size guard (reject > ~2.5MB bodies)
   // if (bodyBytes.byteLength > 2_500_000) return { ok:false, status:413, msg:"Payload too large" };
 
-  return { ok: true, status: 200, msg: "OK", devId: dev.id, supabase };
+  return {
+    ok: true,
+    status: 200,
+    msg: "OK",
+    devId: dev.id,
+    supabase,
+    deviceSecret: dev.secret,
+  };
 }


### PR DESCRIPTION
## Summary
- expose the device secret from ingest-snapshot authentication so downstream logic can sign requests
- derive alert metadata from the uploaded reading, invoke the alerts-create function, and store the returned ids
- link the first created alert to the snapshot record and surface alert ids in the ingest response

## Testing
- deno fmt supabase/functions/ingest-snapshot/index.ts supabase/functions/ingest-snapshot/_auth.ts *(fails: deno not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d17a1f6c48832ebe96fc5e1b9ea255